### PR TITLE
IOCallable does not need to wrap exceptions

### DIFF
--- a/src/main/java/org/zalando/fahrschein/IOCallable.java
+++ b/src/main/java/org/zalando/fahrschein/IOCallable.java
@@ -1,20 +1,9 @@
 package org.zalando.fahrschein;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.concurrent.Callable;
 
 @FunctionalInterface
-public interface IOCallable<T> {
+public interface IOCallable<T> extends Callable<T> {
     T call() throws IOException;
-
-    default Callable<T> unchecked() {
-        return () -> {
-            try {
-                return call();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
-    }
 }


### PR DESCRIPTION
Fixes #58 