### PR TITLE
Provide additional MetricsCollectors

### DIFF
--- a/src/main/java/org/zalando/fahrschein/metrics/LastActivityMetricsCollector.java
+++ b/src/main/java/org/zalando/fahrschein/metrics/LastActivityMetricsCollector.java
@@ -1,0 +1,70 @@
+package org.zalando.fahrschein.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.function.LongSupplier;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static java.lang.System.currentTimeMillis;
+
+public class LastActivityMetricsCollector implements MetricsCollector {
+
+    private long lastMessageReceived = 0;
+    private long lastMessageSuccessfullyProcessed = 0;
+    private long lastEventReceived = 0;
+    private long lastErrorHappend = 0;
+    private long lastReconnect = 0;
+
+    private final MetricRegistry metricRegistry;
+
+    public LastActivityMetricsCollector(final MetricRegistry metricRegistry, final String metricsNamePrefix) {
+        this.metricRegistry = metricRegistry;
+
+        createOrReplaceGauge(metricRegistry,
+                name(this.getClass(), metricsNamePrefix, "lastMessageReceived"),
+                () -> ((currentTimeMillis() - lastMessageReceived) / 1000));
+        createOrReplaceGauge(metricRegistry,
+                name(this.getClass(), metricsNamePrefix, "lastMessageSuccessfullyProcessed"),
+                () -> ((currentTimeMillis() - lastMessageSuccessfullyProcessed) / 1000));
+        createOrReplaceGauge(metricRegistry,
+                name(this.getClass(), metricsNamePrefix, "lastEventReceived"),
+                () -> ((currentTimeMillis() - lastEventReceived) / 1000));
+        createOrReplaceGauge(metricRegistry,
+                name(this.getClass(), metricsNamePrefix, "lastErrorHappend"),
+                () -> ((currentTimeMillis() - lastErrorHappend) / 1000));
+        createOrReplaceGauge(metricRegistry,
+                name(this.getClass(), metricsNamePrefix, "lastReconnect"),
+                () -> ((currentTimeMillis() - lastReconnect) / 1000));
+    }
+
+    private void createOrReplaceGauge(final MetricRegistry metricRegistry, final String gaugeName, final LongSupplier gaugeValueSupplier) {
+        metricRegistry.remove(gaugeName);
+        metricRegistry.register(gaugeName, (Gauge<Integer>) () -> (int) gaugeValueSupplier.getAsLong());
+    }
+
+    @Override
+    public void markMessageReceived() {
+        lastMessageReceived = currentTimeMillis();
+    }
+
+    @Override
+    public void markEventsReceived(final int size) {
+        lastEventReceived = currentTimeMillis();
+    }
+
+    @Override
+    public void markErrorWhileConsuming() {
+        lastErrorHappend = currentTimeMillis();
+    }
+
+    @Override
+    public void markReconnection() {
+        lastReconnect = currentTimeMillis();
+    }
+
+    @Override
+    public void markMessageSuccessfullyProcessed() {
+        lastMessageSuccessfullyProcessed = currentTimeMillis();
+    }
+}

--- a/src/main/java/org/zalando/fahrschein/metrics/MultiplexingMetricsCollector.java
+++ b/src/main/java/org/zalando/fahrschein/metrics/MultiplexingMetricsCollector.java
@@ -1,0 +1,40 @@
+package org.zalando.fahrschein.metrics;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+public class MultiplexingMetricsCollector implements MetricsCollector {
+
+    private final Collection<MetricsCollector> delegates = new LinkedList<>();
+
+    @Override
+    public void markMessageReceived() {
+        delegates.stream().forEach(mc -> mc.markMessageReceived());
+    }
+
+    @Override
+    public void markEventsReceived(final int i) {
+        delegates.stream().forEach(mc -> mc.markEventsReceived(i));
+    }
+
+    @Override
+    public void markErrorWhileConsuming() {
+        delegates.stream().forEach(mc -> mc.markErrorWhileConsuming());
+    }
+
+    @Override
+    public void markReconnection() {
+        delegates.stream().forEach(mc -> mc.markReconnection());
+    }
+
+    @Override
+    public void markMessageSuccessfullyProcessed() {
+        delegates.stream().forEach(mc -> mc.markMessageSuccessfullyProcessed());
+    }
+
+    public MultiplexingMetricsCollector register(final MetricsCollector metricsCollector) {
+        delegates.add(metricsCollector);
+        return this;
+    }
+
+}


### PR DESCRIPTION
- `MultiplexingMetricsCollector`: To be able to register multiple `MetricCollector`s:
- `LastActivityMetricsCollector`: In the past we often wanted to build health checks to detect that Fahrschein doesn't consume any events anymore. The Problem with the Dropwizard metric library is that it uses decaying function such that a metric never reaches exact `0`. With this `MetricCollector` one can build alerts like "_Haven't consumed any event since 10 minutes_" and restart the consumer if necessary (sometimes just reconnect helped if the `ClientHttpRequest` stucked silently).

@jhorstmann @lukasniemeier-zalando 
