### PR TITLE
Get rid of too many parameters of the listen() method

### DIFF
--- a/src/main/java/org/zalando/fahrschein/NakadiClient.java
+++ b/src/main/java/org/zalando/fahrschein/NakadiClient.java
@@ -73,11 +73,11 @@ public class NakadiClient {
         }
     }
 
-    public <T> PreparedListening prepareListening(Subscription subscription, Class<T> eventType, Listener<T> listener) throws IOException {
+    public <T> PreparedListening<T> prepareListening(Subscription subscription, Class<T> eventType, Listener<T> listener) throws IOException {
         return new SubscriptionApiPreparedListening<>(nakadiReaderFactory, baseUri, eventType, listener, subscription);
     }
 
-    public <T> PreparedListening prepareListening(String eventName, Class<T> eventType, Listener<T> listener) throws IOException {
+    public <T> PreparedListening<T> prepareListening(String eventName, Class<T> eventType, Listener<T> listener) throws IOException {
         return new LowLevelApiPreparedListening<>(nakadiReaderFactory, baseUri, eventType, listener, eventName);
     }
 }

--- a/src/main/java/org/zalando/fahrschein/NakadiReaderFactory.java
+++ b/src/main/java/org/zalando/fahrschein/NakadiReaderFactory.java
@@ -14,18 +14,16 @@ class NakadiReaderFactory {
     private final BackoffStrategy backoffStrategy;
     private final CursorManager cursorManager;
     private final ObjectMapper objectMapper;
-    private final MetricsCollector metricsCollector;
 
-    NakadiReaderFactory(final ClientHttpRequestFactory clientHttpRequestFactory, final BackoffStrategy backoffStrategy, final CursorManager cursorManager, final ObjectMapper objectMapper, MetricsCollector metricsCollector) {
+    NakadiReaderFactory(final ClientHttpRequestFactory clientHttpRequestFactory, final BackoffStrategy backoffStrategy, final CursorManager cursorManager, final ObjectMapper objectMapper) {
         this.clientHttpRequestFactory = clientHttpRequestFactory;
         this.backoffStrategy = backoffStrategy;
         this.cursorManager = cursorManager;
         this.objectMapper = objectMapper;
-        this.metricsCollector = metricsCollector;
     }
 
     <T> NakadiReader<T> createReader(final URI uri, final String eventName, final Optional<Subscription> subscription,
-            final Class<T> eventType, final Listener<T> listener) {
+            final Class<T> eventType, final Listener<T> listener, final MetricsCollector metricsCollector) {
 
         return new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
                 eventName, subscription, eventType, listener, metricsCollector);

--- a/src/main/java/org/zalando/fahrschein/PreparedListening.java
+++ b/src/main/java/org/zalando/fahrschein/PreparedListening.java
@@ -1,0 +1,80 @@
+package org.zalando.fahrschein;
+
+import com.google.common.collect.Iterables;
+import org.zalando.fahrschein.domain.Subscription;
+import org.zalando.fahrschein.metrics.MetricsCollector;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import static org.zalando.fahrschein.metrics.NoMetricsCollector.NO_METRICS_COLLECTOR;
+
+public abstract class PreparedListening<T> {
+
+    protected final NakadiReaderFactory nakadiReaderFactory;
+    protected final URI baseUri;
+    protected StreamParameters streamParameters = new StreamParameters();
+    protected final Class<T> eventType;
+    protected final Listener<T> listener;
+    protected MetricsCollector metricsCollector = NO_METRICS_COLLECTOR;
+
+    protected PreparedListening(final NakadiReaderFactory nakadiReaderFactory, final URI baseUri, final Class<T> eventType, final Listener<T> listener) {
+        this.nakadiReaderFactory = nakadiReaderFactory;
+        this.baseUri = baseUri;
+        this.eventType = eventType;
+        this.listener = listener;
+    }
+
+    public PreparedListening withStreamParameters(final StreamParameters streamParameters) {
+        this.streamParameters = streamParameters;
+        return this;
+    }
+
+    public PreparedListening withMetricCollector(final MetricsCollector metricsCollector) {
+        this.metricsCollector = metricsCollector;
+        return this;
+    }
+
+    public abstract void startListening() throws IOException;
+
+    /* LowLevelApiPrepareListening */
+    public static class LowLevelApiPreparedListening<T> extends PreparedListening<T> {
+
+        private final String eventName;
+
+        LowLevelApiPreparedListening(final NakadiReaderFactory nakadiReaderFactory, final URI baseUri, final Class<T> eventType, final Listener<T> listener, final String eventName) {
+            super(nakadiReaderFactory, baseUri, eventType, listener);
+            this.eventName = eventName;
+        }
+
+        @Override
+        public void startListening() throws IOException {
+            final String queryString = streamParameters.toQueryString();
+            final URI uri = baseUri.resolve(String.format("/event-types/%s/events?%s", eventName, queryString));
+            final NakadiReader<T> nakadiReader = nakadiReaderFactory.createReader(uri, eventName, Optional.<Subscription>empty(), eventType, listener, metricsCollector);
+            nakadiReader.run();
+        }
+    }
+
+    /* SubscriptionApiPrepareListening */
+    public static class SubscriptionApiPreparedListening<T> extends PreparedListening<T> {
+
+        private final Subscription subscription;
+
+        protected SubscriptionApiPreparedListening(final NakadiReaderFactory nakadiReaderFactory, final URI baseUri, final Class<T> eventType, final Listener<T> listener, final Subscription subscription) {
+            super(nakadiReaderFactory, baseUri, eventType, listener);
+            this.subscription = subscription;
+        }
+
+        @Override
+        public void startListening() throws IOException {
+            final String eventName = Iterables.getOnlyElement(subscription.getEventTypes());
+            final String queryString = streamParameters.toQueryString();
+            final URI uri = baseUri.resolve(String.format("/subscriptions/%s/events?%s", subscription.getId(), queryString));
+            final NakadiReader<T> nakadiReader = nakadiReaderFactory.createReader(uri, eventName, Optional.of(subscription), eventType, listener, metricsCollector);
+            nakadiReader.run();
+        }
+    }
+
+}

--- a/src/main/java/org/zalando/fahrschein/PreparedListening.java
+++ b/src/main/java/org/zalando/fahrschein/PreparedListening.java
@@ -26,12 +26,12 @@ public abstract class PreparedListening<T> {
         this.listener = listener;
     }
 
-    public PreparedListening withStreamParameters(final StreamParameters streamParameters) {
+    public PreparedListening<T> withStreamParameters(final StreamParameters streamParameters) {
         this.streamParameters = streamParameters;
         return this;
     }
 
-    public PreparedListening withMetricCollector(final MetricsCollector metricsCollector) {
+    public PreparedListening<T> withMetricCollector(final MetricsCollector metricsCollector) {
         this.metricsCollector = metricsCollector;
         return this;
     }

--- a/src/test/java/org/zalando/fahrschein/salesorder/Main.java
+++ b/src/test/java/org/zalando/fahrschein/salesorder/Main.java
@@ -24,11 +24,9 @@ import org.zalando.fahrschein.InMemoryPartitionManager;
 import org.zalando.fahrschein.Listener;
 import org.zalando.fahrschein.NakadiClient;
 import org.zalando.fahrschein.ProblemHandlingClientHttpRequestFactory;
-import org.zalando.fahrschein.StreamParameters;
 import org.zalando.fahrschein.ZignAccessTokenProvider;
 import org.zalando.fahrschein.domain.Cursor;
 import org.zalando.fahrschein.domain.Partition;
-import org.zalando.fahrschein.metrics.NoMetricsCollector;
 import org.zalando.fahrschein.salesorder.domain.SalesOrderPlaced;
 import org.zalando.jackson.datatype.money.MoneyModule;
 
@@ -97,7 +95,7 @@ public class Main {
 
         final ExponentialBackoffStrategy exponentialBackoffStrategy = new ExponentialBackoffStrategy();
 
-        final NakadiClient nakadiClient = new NakadiClient(baseUri, requestFactory, exponentialBackoffStrategy, objectMapper, cursorManager, NoMetricsCollector.NO_METRICS_COLLECTOR);
+        final NakadiClient nakadiClient = new NakadiClient(baseUri, requestFactory, exponentialBackoffStrategy, objectMapper, cursorManager);
 
         final List<Partition> partitions = nakadiClient.getPartitions(eventName);
 
@@ -106,7 +104,7 @@ public class Main {
             cursorManager.onSuccess(eventName, new Cursor(partition.getPartition(), "BEGIN"));
         }
 
-        nakadiClient.listen(eventName, SalesOrderPlaced.class, listener, new StreamParameters());
+        nakadiClient.prepareListening(eventName, SalesOrderPlaced.class, listener).startListening();
         /*
         final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(4);
 


### PR DESCRIPTION
The parameters that are passed in to the `NakadiClient.listen()` method tend to get more and more. For better handling use a DSL to setup listening. One can use it like this:

```
nakadiClient.prepareListening("zalando-sales-offers", SalesOffer.class, new SalesOffersListener())
        .withStreamParameters(myCustomStreamParameters)
        .withMetricCollector(new DropwizardMetricsCollector(metricRegistry, "salesOffers"))
        .startListening();
```

@jhorstmann @lukasniemeier-zalando 
