### PR TITLE
close input stream before entity to circumvent draining

### DIFF
--- a/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -110,7 +110,12 @@ class NakadiReader<T> implements IORunnable {
                 LOG.warn("Could not close json parser", e);
             } finally {
                 LOG.trace("Trying to close response");
-                response.close();
+                try {
+                	response.getBody().close();
+                	response.close();
+                } catch (IOException e) {
+                	LOG.warn("Could not close response stream.", e);
+                }
                 LOG.trace("Closed response");
             }
         }


### PR DESCRIPTION
This change closes the input stream from the HTTP entity upfront, so that the call to close on the HttpResponseEntity can't drain it.
