### PR TITLE
Extend MetricsCollector to be informed about occurred_at timestamps.

### DIFF
--- a/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/DropwizardMetricsCollector.java
+++ b/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/DropwizardMetricsCollector.java
@@ -4,6 +4,9 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import org.zalando.fahrschein.MetricsCollector;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 public class DropwizardMetricsCollector implements MetricsCollector {
 
     public static final String DEFAULT_PREFIX = "org.zalando.fahrschein.";
@@ -32,7 +35,7 @@ public class DropwizardMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void markEventsReceived(final int size) {
+    public void markEventsReceived(final int size, final Optional<OffsetDateTime> oldestOccurredAt, final Optional<OffsetDateTime> latestOccurredAt) {
         eventsReceivedMeter.mark(size);
     }
 

--- a/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/EventOccurredAtMetricsCollector.java
+++ b/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/EventOccurredAtMetricsCollector.java
@@ -1,0 +1,31 @@
+package org.zalando.fahrschein.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class EventOccurredAtMetricsCollector extends MetricsCollectorAdapter {
+
+    private OffsetDateTime oldestOccurredAt;
+    private OffsetDateTime latestOccurredAt;
+
+    public EventOccurredAtMetricsCollector(final MetricRegistry metricRegistry, final String metricsNamePrefix) {
+        createOrReplaceGauge(metricRegistry, metricsNamePrefix + "oldestOccurredAt", () -> this.oldestOccurredAt);
+        createOrReplaceGauge(metricRegistry, metricsNamePrefix + "latestOccurredAt", () -> this.latestOccurredAt);
+    }
+
+    @Override
+    public void markEventsReceived(final int size, final Optional<OffsetDateTime> oldestOccurredAt, final Optional<OffsetDateTime> latestOccurredAt) {
+        oldestOccurredAt.ifPresent(value -> this.oldestOccurredAt = value);
+        latestOccurredAt.ifPresent(value -> this.latestOccurredAt = value);
+    }
+
+    private static void createOrReplaceGauge(final MetricRegistry metricRegistry, final String gaugeName, final Supplier<OffsetDateTime> gaugeValueSupplier) {
+        metricRegistry.remove(gaugeName);
+        metricRegistry.register(gaugeName, (Gauge<OffsetDateTime>) gaugeValueSupplier::get);
+    }
+
+}

--- a/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/LastActivityMetricsCollector.java
+++ b/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/LastActivityMetricsCollector.java
@@ -4,6 +4,8 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import org.zalando.fahrschein.MetricsCollector;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.function.LongSupplier;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -17,11 +19,7 @@ public class LastActivityMetricsCollector implements MetricsCollector {
     private long lastErrorHappend = 0;
     private long lastReconnect = 0;
 
-    private final MetricRegistry metricRegistry;
-
     public LastActivityMetricsCollector(final MetricRegistry metricRegistry, final String metricsNamePrefix) {
-        this.metricRegistry = metricRegistry;
-
         createOrReplaceGauge(metricRegistry,
                 name(this.getClass(), metricsNamePrefix, "lastMessageReceived"),
                 () -> ((currentTimeMillis() - lastMessageReceived) / 1000));
@@ -50,7 +48,7 @@ public class LastActivityMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void markEventsReceived(final int size) {
+    public void markEventsReceived(final int size, final Optional<OffsetDateTime> oldestOccurredAt, final Optional<OffsetDateTime> latestOccurredAt) {
         lastEventReceived = currentTimeMillis();
     }
 

--- a/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/MetricsCollectorAdapter.java
+++ b/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/MetricsCollectorAdapter.java
@@ -1,0 +1,34 @@
+package org.zalando.fahrschein.metrics;
+
+import org.zalando.fahrschein.MetricsCollector;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public abstract class MetricsCollectorAdapter implements MetricsCollector {
+
+    @Override
+    public void markMessageReceived() {
+
+    }
+
+    @Override
+    public void markEventsReceived(final int size, final  Optional<OffsetDateTime> oldestOccurredAt, final  Optional<OffsetDateTime> latestOccurredAt) {
+
+    }
+
+    @Override
+    public void markErrorWhileConsuming() {
+
+    }
+
+    @Override
+    public void markReconnection() {
+
+    }
+
+    @Override
+    public void markMessageSuccessfullyProcessed() {
+
+    }
+}

--- a/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/MultiplexingMetricsCollector.java
+++ b/fahrschein-metrics-dropwizard/src/main/java/org/zalando/fahrschein/metrics/MultiplexingMetricsCollector.java
@@ -2,8 +2,10 @@ package org.zalando.fahrschein.metrics;
 
 import org.zalando.fahrschein.MetricsCollector;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Optional;
 
 public class MultiplexingMetricsCollector implements MetricsCollector {
 
@@ -15,8 +17,8 @@ public class MultiplexingMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void markEventsReceived(final int i) {
-        delegates.stream().forEach(mc -> mc.markEventsReceived(i));
+    public void markEventsReceived(final int i, final Optional<OffsetDateTime> oldestOccurredAt, final Optional<OffsetDateTime> latestOccurredAt) {
+        delegates.stream().forEach(mc -> mc.markEventsReceived(i, oldestOccurredAt, latestOccurredAt));
     }
 
     @Override

--- a/fahrschein/src/main/java/org/zalando/fahrschein/MetricsCollector.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/MetricsCollector.java
@@ -1,9 +1,12 @@
 package org.zalando.fahrschein;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 public interface MetricsCollector {
     void markMessageReceived();
 
-    void markEventsReceived(int size);
+    void markEventsReceived(int size, Optional<OffsetDateTime> oldestOccurredAt, Optional<OffsetDateTime> latestOccurredAt);
 
     void markErrorWhileConsuming();
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -3,11 +3,12 @@ package org.zalando.fahrschein;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ValueNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
@@ -25,10 +26,11 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -111,6 +113,28 @@ class NakadiReader<T> implements IORunnable {
                 response.close();
                 LOG.trace("Closed response");
             }
+        }
+    }
+
+    private static class EventsStatistic {
+        private OffsetDateTime oldestOccurredAt = null;
+        private OffsetDateTime latestOccurredAt = null;
+
+        void applyOccurredAt(final OffsetDateTime occurredAt) {
+            if(oldestOccurredAt == null || occurredAt.isBefore(oldestOccurredAt)) {
+                oldestOccurredAt = occurredAt;
+            }
+            if(latestOccurredAt == null || occurredAt.isAfter(latestOccurredAt)) {
+                latestOccurredAt = occurredAt;
+            }
+        }
+
+        Optional<OffsetDateTime> getOldestOccurredAt() {
+            return Optional.ofNullable(oldestOccurredAt);
+        }
+
+        Optional<OffsetDateTime> getLatestOccurredAt() {
+            return Optional.ofNullable(latestOccurredAt);
         }
     }
 
@@ -212,33 +236,31 @@ class NakadiReader<T> implements IORunnable {
         return new Cursor(partition, offset, eventType, cursorToken);
     }
 
-    private List<T> readEvents(final JsonParser jsonParser) throws IOException {
+    private List<T> readEvents(final JsonParser jsonParser, final EventsStatistic eventsStatistic) throws IOException {
         expectToken(jsonParser, JsonToken.START_ARRAY);
         jsonParser.clearCurrentToken();
 
-        final Iterator<T> eventIterator = eventReader.readValues(jsonParser, eventClass);
-
         final List<T> events = new ArrayList<>();
-        while (true) {
-            try {
-                // MappingIterator#hasNext can theoretically also throw RuntimeExceptions, that's why we use this strange loop structure
-                if (eventIterator.hasNext()) {
-                    events.add(eventClass.cast(eventIterator.next()));
-                } else {
-                    break;
-                }
-            } catch (RuntimeException e) {
-                final Throwable cause = e.getCause();
-                if (cause instanceof JsonMappingException) {
-                    listener.onMappingException((JsonMappingException) cause);
-                } else if (cause instanceof IOException) {
-                    throw (IOException)cause;
-                } else {
-                    throw e;
-                }
-            }
+        while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+            final TreeNode eventAsTree = jsonParser.readValueAsTree();
+
+            events.add(eventReader.treeToValue(eventAsTree, eventClass));
+            extractOccurredAt(eventAsTree).ifPresent(eventsStatistic::applyOccurredAt);
         }
         return events;
+    }
+
+    private Optional<OffsetDateTime> extractOccurredAt(final TreeNode eventAsTree) {
+        final Optional<String> occurredAtAsString = Optional.of(eventAsTree.path("metadata").path("occurred_at"))
+                .filter(TreeNode::isValueNode)
+                .map(node -> (ValueNode) node)
+                .map(ValueNode::asText);
+        try {
+            return occurredAtAsString.map(OffsetDateTime::parse);
+        } catch (DateTimeParseException ex) {
+            LOG.info("Could not parse \"metadata.occurred_at\":\"{}\" as offset date time: {}", occurredAtAsString.get(), ex.getMessage());
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -326,6 +348,7 @@ class NakadiReader<T> implements IORunnable {
 
         Cursor cursor = null;
         List<T> events = null;
+        final EventsStatistic eventsStatistic = new EventsStatistic();
 
         while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
             final String field = jsonParser.getCurrentName();
@@ -335,7 +358,7 @@ class NakadiReader<T> implements IORunnable {
                     break;
                 }
                 case "events": {
-                    events = readEvents(jsonParser);
+                    events = readEvents(jsonParser, eventsStatistic);
                     break;
                 }
                 case "info": {
@@ -360,9 +383,9 @@ class NakadiReader<T> implements IORunnable {
         LOG.debug("Cursor for [{}] partition [{}] at offset [{}]", eventName, cursor.getPartition(), cursor.getOffset());
 
         if (events == null) {
-            metricsCollector.markEventsReceived(0);
+            metricsCollector.markEventsReceived(0, Optional.empty(), Optional.empty());
         } else {
-            metricsCollector.markEventsReceived(events.size());
+            metricsCollector.markEventsReceived(events.size(), eventsStatistic.getOldestOccurredAt(), eventsStatistic.getLatestOccurredAt());
 
             final Batch<T> batch = new Batch<>(cursor, Collections.unmodifiableList(events));
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NoMetricsCollector.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NoMetricsCollector.java
@@ -1,5 +1,8 @@
 package org.zalando.fahrschein;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 public class NoMetricsCollector implements MetricsCollector {
 
     public static final NoMetricsCollector NO_METRICS_COLLECTOR = new NoMetricsCollector();
@@ -10,7 +13,7 @@ public class NoMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void markEventsReceived(final int size) {
+    public void markEventsReceived(final int size, final Optional<OffsetDateTime> oldestOccurredAt, final Optional<OffsetDateTime> latestOccurredAt) {
         // do nothing
     }
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -1,20 +1,21 @@
 package org.zalando.fahrschein;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.hobsoft.hamcrest.compose.ComposeMatchers;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
@@ -54,24 +55,37 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zalando.fahrschein.NoMetricsCollector.NO_METRICS_COLLECTOR;
 
+@RunWith(MockitoJUnitRunner.class)
 public class NakadiReaderTest {
 
     private static final String EVENT_NAME = "some-event";
     private final URI uri = java.net.URI.create("http://example.com/events");
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final CursorManager cursorManager = mock(CursorManager.class);
-    private final ClientHttpRequestFactory clientHttpRequestFactory = mock(ClientHttpRequestFactory.class);
 
-    @SuppressWarnings("unchecked")
-    private final Listener<SomeEvent> listener = (Listener<SomeEvent>)mock(Listener.class);
+    @Mock
+    private CursorManager cursorManager;
+
+    @Mock
+    private ClientHttpRequestFactory clientHttpRequestFactory;
+
+    @Mock
+    private Listener<SomeEvent> listener;
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private ClientHttpRequest request;
+
+    @Mock
+    private ClientHttpResponse response;
+
+    @Mock
+    private MetricsCollector metricsCollector;
 
     public static class SomeEvent {
         private String id;
@@ -85,16 +99,17 @@ public class NakadiReaderTest {
         }
     }
 
+    @Before
+    public void setUp() throws Exception {
+        when(request.execute()).thenReturn(response);
+        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
+    }
+
     @Test
     public void shouldNotRetryInitialConnection() throws IOException {
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
         when(request.execute()).thenThrow(new IOException("Initial connection failed"));
 
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(IOException.class);
         expectedException.expectMessage(equalTo("Initial connection failed"));
@@ -104,17 +119,9 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldNotReconnectWithoutBackoff() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(emptyInputStream);
+        when(response.getBody()).thenReturn(emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature("retries", BackoffException::getRetries, equalTo(0)));
@@ -125,17 +132,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldHandleBrokenInput() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"".getBytes("utf-8"));
         when(response.getBody()).thenReturn(initialInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -147,17 +147,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldHandleBrokenInputInEvents() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":".getBytes("utf-8"));
         when(response.getBody()).thenReturn(initialInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -169,14 +162,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldRetryConnectionOnEof() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"}}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(initialInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
         when(request.execute()).thenReturn(response).thenThrow(new IOException("Reconnection failed"));
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 1);
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
@@ -191,14 +180,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldRetryConnectionMultipleTimesOnEof() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"}}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(initialInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
         when(request.execute()).thenReturn(response).thenThrow(new IOException("Reconnection failed"));
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
@@ -213,14 +198,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldRetryConnectionAfterExceptionDuringReconnection() throws IOException, InterruptedException, BackoffException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"}}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(initialInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
         when(request.execute()).thenReturn(response).thenThrow(new IOException("Reconnection failed")).thenReturn(response).thenThrow(new IOException("Reconnection failed on second attempt"));
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
@@ -252,7 +233,6 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldBeInterruptible() throws IOException, InterruptedException, BackoffException, ExecutionException, TimeoutException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final InputStream endlessInputStream = new SequenceInputStream(new Enumeration<InputStream>() {
             @Override
             public boolean hasMoreElements() {
@@ -270,13 +250,7 @@ public class NakadiReaderTest {
         });
         when(response.getBody()).thenReturn(endlessInputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         //expectedException.expect(InterruptedException.class);
 
@@ -293,7 +267,6 @@ public class NakadiReaderTest {
 
     @Test(timeout = 2000)
     public void shouldBeInterruptibleWhenReadingFromSocket() throws IOException, InterruptedException, BackoffException, ExecutionException, TimeoutException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
         final ServerSocket serverSocket = new ServerSocket(0, 0, loopbackAddress);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -321,13 +294,7 @@ public class NakadiReaderTest {
         final InputStream inputStream = socket.getInputStream();
         when(response.getBody()).thenReturn(inputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final BackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(2);
         final Future<?> future = scheduledExecutorService.submit(() -> {
@@ -341,20 +308,13 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldReturnInsteadOfReconnectOnInterruption() throws IOException, InterruptedException, BackoffException, ExecutionException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"}}".getBytes("utf-8"));
         when(response.getBody()).thenAnswer(invocation -> {
             Thread.currentThread().interrupt();
             return initialInputStream;
         });
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         final Future<?> future = Executors.newCachedThreadPool().submit(nakadiReader.unchecked());
         Assert.assertNull("Thread should have completed normally", future.get());
@@ -362,21 +322,13 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldReturnOnInterruptionDuringReconnection() throws IOException, InterruptedException, BackoffException, ExecutionException {
-        final ClientHttpResponse initialResponse = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"}}".getBytes("utf-8"));
-        when(initialResponse.getBody()).thenReturn(initialInputStream);
+        when(response.getBody()).thenReturn(initialInputStream);
 
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        final ClientHttpResponse emptyResponse = mock(ClientHttpResponse.class);
-        when(emptyResponse.getBody()).thenReturn(emptyInputStream);
-
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(initialResponse).thenAnswer(invocation -> {
+        when(request.execute()).thenReturn(response).thenAnswer(invocation -> {
             Thread.currentThread().interrupt();
             throw new IOException("Reconnection failed");
         });
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
@@ -387,18 +339,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldProcessEventsAndCommitCursor() throws IOException, InterruptedException, BackoffException, EventAlreadyProcessedException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"}]}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         // cannot use expectedException since there should be assertions afterwards
         try {
@@ -433,17 +377,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldFailWithoutCursors() throws IOException, InterruptedException, BackoffException, EventAlreadyProcessedException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"foo\":\"bar\"}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(inputStream);
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -455,18 +392,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldIgnoreMetadataInEventBatch() throws IOException, InterruptedException, BackoffException, EventAlreadyProcessedException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -478,18 +407,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldIgnoreAdditionalPropertiesInEventBatch() throws IOException, InterruptedException, BackoffException, EventAlreadyProcessedException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"foo\":\"bar\",\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -501,18 +422,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldIgnoreAdditionalPropertiesInEventBatchInAnyOrder() throws IOException, InterruptedException, BackoffException, EventAlreadyProcessedException {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"foo\":\"bar\",\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"}],\"baz\":123}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -524,19 +437,14 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldSendCursorsForLockedPartitions() throws IOException {
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
         when(request.execute()).thenThrow(new IOException("Initial connection failed"));
         final HttpHeaders headers = new HttpHeaders();
         when(request.getHeaders()).thenReturn(headers);
 
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-
         when(cursorManager.getCursors(EVENT_NAME)).thenReturn(asList(new Cursor("0", "0"), new Cursor("1", "10"), new Cursor("2", "20"), new Cursor("3", "30")));
 
         final Lock lock = new Lock(EVENT_NAME, "test", asList(new Partition("0", "0", "100"), new Partition("1", "0", "100")));
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.of(lock), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.of(lock), SomeEvent.class, listener, NO_METRICS_COLLECTOR);
 
         expectedException.expect(IOException.class);
         expectedException.expectMessage(equalTo("Initial connection failed"));
@@ -549,20 +457,10 @@ public class NakadiReaderTest {
 
     @Test
     public void shouldCallMetricsCollectorWithoutMetadataBeingPresent() throws Exception {
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"},{\"id\":\"790\"}]}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final MetricsCollector metricsCollector = mock(MetricsCollector.class);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, metricsCollector);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, metricsCollector);
 
         try {
             nakadiReader.runInternal();
@@ -583,20 +481,10 @@ public class NakadiReaderTest {
         final OffsetDateTime olderOccurredAt = OffsetDateTime.parse("2007-12-03T10:14:30+01:00");
         final OffsetDateTime newerOccurredAt = OffsetDateTime.parse("2007-12-03T10:15:30+01:00");
 
-        final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\",\"metadata\":\"illegal\"},{\"id\":\"790\",\"metadata\":{\"occurred_at\":\"2007-12-03T10:15:30+01:00\"}},{\"id\":\"791\",\"metadata\":{\"occurred_at\":\"2007-12-03T10:14:30+01:00\"}}]}".getBytes("utf-8"));
-        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
-        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream());
 
-        final ClientHttpRequest request = mock(ClientHttpRequest.class);
-        when(request.execute()).thenReturn(response);
-
-        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
-
-        final MetricsCollector metricsCollector = mock(MetricsCollector.class);
-
-        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, metricsCollector);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, noBackoffStrategy(), cursorManager, objectMapper, EVENT_NAME, Optional.empty(), Optional.empty(), SomeEvent.class, listener, metricsCollector);
 
         try {
             nakadiReader.runInternal();
@@ -604,5 +492,13 @@ public class NakadiReaderTest {
         } catch (BackoffException e) {
             verify(metricsCollector).markEventsReceived(3, Optional.of(olderOccurredAt), Optional.of(newerOccurredAt));
         }
+    }
+
+    private static InputStream emptyInputStream() {
+        return new ByteArrayInputStream(new byte[0]);
+    }
+
+    private static NoBackoffStrategy noBackoffStrategy() {
+        return new NoBackoffStrategy();
     }
 }


### PR DESCRIPTION
Addressing https://github.com/zalando-incubator/fahrschein/issues/126
* changing method markEventsReceived of MetricsCollector
* NakadiReader inspects events and checks whether metadata.occurred_at timestamp is present