### PR TITLE
Close subscription on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,13 @@ Subscription subscriptions = nakadiClient.subscription(applicationName, eventNam
 
 // Start streaming, the listen call will block and automatically reconnect on IOException
 new Thread(() -> {
-nakadiClient.stream(subscription)
-        .withReaderManager(readerManager)
-        .listen(SalesOrderPlaced.class, listener);  
+  try {
+    nakadiClient.stream(subscription)
+                .withReaderManager(readerManager)
+                .listen(SalesOrderPlaced.class, listener);
+  } catch (IOException e) {
+    e.printStackTrace();
+  }
 }).run();
 
 // let it run for 1 minute
@@ -217,17 +221,17 @@ Thread.sleep(60*1000);
 // and stop the reading
 readerManager.discontinueReading();
 
-// let's wait a minute
-Thread.sleep(60*1000);
+// let's wait a moment
+Thread.sleep(1000);
 
 // And another round
 readerManager.continueReading();
 
-new Thread(() -> {
-nakadiClient.stream(subscription)
-        .withReaderManager(readerManager)
-        .listen(SalesOrderPlaced.class, listener);  
-}).run();
+// let it run for 1 minute
+Thread.sleep(60*1000);
+
+//And termination
+readerManager.terminateReader();
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,12 @@ Please note that `HttpComponentsClientHttpRequestFactory` and also `SimpleClient
 
 In order to be able to stop listening on a subscription you need to implement the `ReaderManager` interface.
 
-The interface provides one method `boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be stopped.
+The interface provides two methods 
+ 
+ - `boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be suspended
+ - `boolean terminateReading(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be terminated
+ 
+The difference between both methods is, that `discontinueReading` is revertible without the need to restart the listener. In contrast the `terminateReading` will kill the thread the listener runs in and you need to build a new stream and listen on it.
 
 **Please note** : Resetting the `ReaderManager` is responsibility of the application.
  
@@ -170,17 +175,28 @@ The interface provides one method `boolean continueReading(Set<String> eventName
 public class DemoReaderManager implements ReaderManager {
   
   private boolean discontinueReading = false;
-  
-  boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription) {
+  private boolean terminateReader = false;
+
+  @Override
+  public boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription) {
     return discontinueReading;
   }
-  
+
+  @Override
+  public boolean terminateReader(Set<String> eventNames, Optional<Subscription> subscription) {
+    return terminateReader;
+  }
+
   void discontinueReading() {
     discontinueReading = true;
   }
   
   void continueReading() {
     discontinueReading = false;
+  }
+
+  void terminateReader() {
+    terminateReader = true;
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ In order to be able to stop listening on a subscription you need to implement th
 The interface provides two methods 
  
  - `boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be suspended
- - `boolean terminateReading(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be terminated
+ - `boolean terminateReader(Set<String> eventNames, Optional<Subscription> subscription)` which is used by Fahrschein to check if the listening should be terminated
  
-The difference between both methods is, that `discontinueReading` is revertible without the need to restart the listener. In contrast the `terminateReading` will kill the thread the listener runs in and you need to build a new stream and listen on it.
+The difference between both methods is, that `discontinueReading` is revertible without the need to restart the listener. In contrast the `terminateReader` will kill the thread the listener runs in and you need to build a new stream and listen on it.
 
 **Please note** : Resetting the `ReaderManager` is responsibility of the application.
  

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/DemoReaderManager.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/DemoReaderManager.java
@@ -6,20 +6,30 @@ import org.zalando.fahrschein.domain.Subscription;
 import java.util.Optional;
 import java.util.Set;
 
-public class DemoReaderManager implements ReaderManager {
-  
-  private boolean discontinueReading = false;
+  public class DemoReaderManager implements ReaderManager {
 
-  @Override
-  public boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription) {
-    return discontinueReading;
+    private boolean discontinueReading = false;
+    private boolean terminateReader = false;
+
+    @Override
+    public boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription) {
+      return discontinueReading;
+    }
+
+    @Override
+    public boolean terminateReader(Set<String> eventNames, Optional<Subscription> subscription) {
+      return terminateReader;
+    }
+
+    void discontinueReading() {
+      discontinueReading = true;
+    }
+
+    void continueReading() {
+      discontinueReading = false;
+    }
+
+    void terminateReader() {
+      terminateReader = true;
+    }
   }
-  
-  void discontinueReading() {
-    discontinueReading = true;
-  }
-  
-  void continueReading() {
-    discontinueReading = false;
-  }
-}

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/DemoReaderManager.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/DemoReaderManager.java
@@ -1,0 +1,25 @@
+package org.zalando.fahrschein.example;
+
+import org.zalando.fahrschein.ReaderManager;
+import org.zalando.fahrschein.domain.Subscription;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class DemoReaderManager implements ReaderManager {
+  
+  private boolean discontinueReading = false;
+
+  @Override
+  public boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription) {
+    return discontinueReading;
+  }
+  
+  void discontinueReading() {
+    discontinueReading = true;
+  }
+  
+  void continueReading() {
+    discontinueReading = false;
+  }
+}

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/Main.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/Main.java
@@ -194,27 +194,22 @@ public class Main {
             }
         }).run();
 
+        // let it run for 1 minute
         Thread.sleep(60*1000);
 
+        // and stop the reading
         readerManager.discontinueReading();
 
-        Thread.sleep(60*1000);
+        // let's wait a moment
+        Thread.sleep(1000);
 
+        // And another round
         readerManager.continueReading();
 
-        new Thread(() -> {
-            try {
-                nakadiClient.stream(subscription)
-                            .withReaderManager(readerManager)
-                            .listen(SalesOrderPlaced.class, listener);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }).run();
-
+        // let it run for 1 minute
         Thread.sleep(60*1000);
 
-        readerManager.discontinueReading();
+        readerManager.terminateReader();
     }
 
     private static void simpleListen(ObjectMapper objectMapper, Listener<SalesOrderPlaced> listener) throws IOException {

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/Main.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/Main.java
@@ -54,7 +54,7 @@ public class Main {
     public static final String ORDER_CREATED = "eventlog.e96001_order_created";
     public static final String ORDER_PAYMENT_STATUS_ACCEPTED = "eventlog.e62001_order_payment_status_accepted";
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+    public static void main(String[] args) throws Exception {
 
         final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -82,11 +82,13 @@ public class Main {
             }
         };
 
+        subscriptionListenWithReaderManager(objectMapper, listener);
+
         //subscriptionListen(objectMapper, listener);
 
         //subscriptionListenWithPositionCursors(objectMapper, listener);
 
-        subscriptionMultipleEvents(objectMapper);
+        //subscriptionMultipleEvents(objectMapper);
 
         //simpleListen(objectMapper, listener);
 
@@ -167,6 +169,52 @@ public class Main {
         nakadiClient.stream(subscription)
                 .withObjectMapper(objectMapper)
                 .listen(SalesOrderPlaced.class, listener);
+    }
+
+    private static void subscriptionListenWithReaderManager(ObjectMapper objectMapper, Listener<SalesOrderPlaced> listener) throws Exception {
+
+        final DemoReaderManager readerManager = new DemoReaderManager();
+
+        final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI)
+                                                      .withAccessTokenProvider(new ZignAccessTokenProvider())
+                                                      .build();
+
+        final Subscription subscription = nakadiClient.subscription("fahrschein-demo", SALES_ORDER_SERVICE_ORDER_PLACED)
+                                                      .withConsumerGroup("fahrschein-demo")
+                                                      .readFromEnd()
+                                                      .subscribe();
+
+        new Thread(() -> {
+            try {
+                nakadiClient.stream(subscription)
+                            .withReaderManager(readerManager)
+                            .listen(SalesOrderPlaced.class, listener);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).run();
+
+        Thread.sleep(60*1000);
+
+        readerManager.discontinueReading();
+
+        Thread.sleep(60*1000);
+
+        readerManager.continueReading();
+
+        new Thread(() -> {
+            try {
+                nakadiClient.stream(subscription)
+                            .withReaderManager(readerManager)
+                            .listen(SalesOrderPlaced.class, listener);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).run();
+
+        Thread.sleep(60*1000);
+
+        readerManager.discontinueReading();
     }
 
     private static void simpleListen(ObjectMapper objectMapper, Listener<SalesOrderPlaced> listener) throws IOException {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/DefaultReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/DefaultReaderManager.java
@@ -7,7 +7,12 @@ import java.util.Set;
 
 public class DefaultReaderManager implements ReaderManager {
   @Override
-  public boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription) {
-    return true;
+  public boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription) {
+    return false;
+  }
+
+  @Override
+  public boolean terminateReader(Set<String> eventNames, Optional<Subscription> subscription) {
+    return false;
   }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/DefaultReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/DefaultReaderManager.java
@@ -1,0 +1,13 @@
+package org.zalando.fahrschein;
+
+import org.zalando.fahrschein.domain.Subscription;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class DefaultReaderManager implements ReaderManager {
+  @Override
+  public boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription) {
+    return true;
+  }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
@@ -10,4 +10,11 @@ public interface Listener<T> {
 
     void accept(final List<T> events) throws IOException, EventAlreadyProcessedException;
 
+  /**
+   * A callback for the NakadiReader to check if the listener is still active and ready for consumption of events
+   * @return
+   */
+  default boolean isActive() {
+    return true;
+  }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
@@ -10,11 +10,11 @@ public interface Listener<T> {
 
     void accept(final List<T> events) throws IOException, EventAlreadyProcessedException;
 
-  /**
-   * A callback for the NakadiReader to check if the listener is still active and ready for consumption of events
-   * @return
-   */
-  default boolean isActive() {
-    return true;
-  }
+    /**
+     * A callback for the NakadiReader to check if the listener is still active and ready for consumption of events
+     * @return
+     */
+    default boolean isActive() {
+      return true;
+    }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/Listener.java
@@ -9,12 +9,4 @@ import java.util.List;
 public interface Listener<T> {
 
     void accept(final List<T> events) throws IOException, EventAlreadyProcessedException;
-
-    /**
-     * A callback for the NakadiReader to check if the listener is still active and ready for consumption of events
-     * @return
-     */
-    default boolean isActive() {
-      return true;
-    }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -292,7 +292,7 @@ class NakadiReader<T> implements IORunnable {
 
         int errorCount = 0;
 
-        while (readerManager.continueReading(subscription)) {
+        while (readerManager.continueReading(eventNames, subscription)) {
             try {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -291,7 +291,7 @@ class NakadiReader<T> implements IORunnable {
 
         int errorCount = 0;
 
-        while (true) {
+        while (listener.isActive()) {
             try {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
 
@@ -341,6 +341,7 @@ class NakadiReader<T> implements IORunnable {
                 throw e;
             }
         }
+        jsonInput.close();
     }
 
     /*

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -292,7 +292,7 @@ class NakadiReader<T> implements IORunnable {
 
         int errorCount = 0;
 
-        while (readerManager.continueReading()) {
+        while (readerManager.continueReading(subscription)) {
             try {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -67,7 +67,6 @@ class NakadiReader<T> implements IORunnable {
     private final MetricsCollector metricsCollector;
 
     NakadiReader(URI uri, ClientHttpRequestFactory clientHttpRequestFactory, BackoffStrategy backoffStrategy, CursorManager cursorManager, ObjectMapper objectMapper, Set<String> eventNames, Optional<Subscription> subscription, Optional<Lock> lock, Class<T> eventClass, Listener<T> listener, ErrorHandler errorHandler, ReaderManager readerManager, final MetricsCollector metricsCollector) {
-        this.readerManager = readerManager;
 
         checkState(subscription.isPresent() || eventNames.size() == 1, "Low level api only supports reading from a single event");
 
@@ -81,6 +80,7 @@ class NakadiReader<T> implements IORunnable {
         this.eventClass = eventClass;
         this.listener = listener;
         this.errorHandler = errorHandler;
+        this.readerManager = readerManager;
         this.metricsCollector = metricsCollector;
 
         this.jsonFactory = objectMapper.getFactory();

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -292,9 +292,13 @@ class NakadiReader<T> implements IORunnable {
 
         int errorCount = 0;
 
-        while (readerManager.continueReading(eventNames, subscription)) {
+        while (true) {
             try {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
+
+                if (readerManager.continueReading(eventNames, subscription)) {
+                   throw new ReadingDiscontinuedException();
+                }
 
                 if (Thread.currentThread().isInterrupted()) {
                     throw new InterruptedIOException("Interrupted");

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -296,13 +296,7 @@ class NakadiReader<T> implements IORunnable {
             try {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
 
-                if (readerManager.continueReading(eventNames, subscription)) {
-                   throw new ReadingDiscontinuedException();
-                }
-
-                if (Thread.currentThread().isInterrupted()) {
-                    throw new InterruptedIOException("Interrupted");
-                }
+                verifyReadingCanContinue();
 
                 readBatch(jsonParser);
 
@@ -347,6 +341,16 @@ class NakadiReader<T> implements IORunnable {
             }
         }
         jsonInput.close();
+    }
+
+    private void verifyReadingCanContinue() throws InterruptedIOException {
+        if (!readerManager.continueReading(eventNames, subscription)) {
+           throw new ReadingDiscontinuedException();
+        }
+
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedIOException("Interrupted");
+        }
     }
 
     /*

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -15,11 +15,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
-import org.zalando.fahrschein.domain.Batch;
-import org.zalando.fahrschein.domain.Cursor;
-import org.zalando.fahrschein.domain.Lock;
-import org.zalando.fahrschein.domain.Partition;
-import org.zalando.fahrschein.domain.Subscription;
+import org.zalando.fahrschein.domain.*;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -27,14 +23,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -289,66 +278,92 @@ class NakadiReader<T> implements IORunnable {
         LOG.info("Starting to listen for events for {}", eventNames);
 
         JsonInput jsonInput = openJsonInput();
+        boolean jsonInputIsClosed = false;
 
         int errorCount = 0;
 
-        while (true) {
-            try {
-                final JsonParser jsonParser = jsonInput.getJsonParser();
+    while (true) {
+      try {
 
-                verifyReadingCanContinue();
+        verifyTerminationIsNotRequested();
 
-                readBatch(jsonParser);
+        if (readerManager.discontinueReading(eventNames, subscription)) {
+          stopReadingAndSleep(jsonInput);
+          jsonInputIsClosed = true;
+        } else {
 
-                errorCount = 0;
-            } catch (IOException e) {
+          if (jsonInputIsClosed) {
+            jsonInput = openJsonInput();
+          }
 
-                metricsCollector.markErrorWhileConsuming();
+          final JsonParser jsonParser = jsonInput.getJsonParser();
 
-                if (errorCount > 0) {
-                    LOG.warn("Got [{}] [{}] while reading events for {} after [{}] retries", e.getClass().getSimpleName(), e.getMessage(), eventNames, errorCount, e);
-                } else {
-                    LOG.info("Got [{}] [{}] while reading events for {}", e.getClass().getSimpleName(), e.getMessage(), eventNames, e);
-                }
+          readBatch(jsonParser);
 
-                jsonInput.close();
-
-                if (Thread.currentThread().isInterrupted()) {
-                    LOG.warn("Thread was interrupted");
-                    break;
-                }
-
-                try {
-                    LOG.debug("Reconnecting after [{}] errors", errorCount);
-                    jsonInput = backoffStrategy.call(errorCount, e, this::openJsonInput);
-                    LOG.info("Reconnected after [{}] errors", errorCount);
-                    metricsCollector.markReconnection();
-                } catch (InterruptedException interruptedException) {
-                    LOG.warn("Interrupted during reconnection", interruptedException);
-
-                    Thread.currentThread().interrupt();
-                    return;
-                }
-
-                errorCount++;
-            } catch (Throwable e) {
-                try {
-                    jsonInput.close();
-                } catch (Throwable suppressed) {
-                    e.addSuppressed(e);
-                }
-                throw e;
-            }
+          errorCount = 0;
         }
+      } catch (IOException e) {
+
+        metricsCollector.markErrorWhileConsuming();
+
+        if (errorCount > 0) {
+          LOG.warn("Got [{}] [{}] while reading events for {} after [{}] retries", e.getClass()
+                                                                                    .getSimpleName(), e.getMessage(), eventNames, errorCount, e);
+        } else {
+          LOG.info("Got [{}] [{}] while reading events for {}", e.getClass()
+                                                                 .getSimpleName(), e.getMessage(), eventNames, e);
+        }
+
         jsonInput.close();
+
+        if (Thread.currentThread()
+                  .isInterrupted()) {
+          LOG.warn("Thread was interrupted");
+          break;
+        }
+
+        try {
+          LOG.debug("Reconnecting after [{}] errors", errorCount);
+          jsonInput = backoffStrategy.call(errorCount, e, this::openJsonInput);
+          LOG.info("Reconnected after [{}] errors", errorCount);
+          metricsCollector.markReconnection();
+        } catch (InterruptedException interruptedException) {
+          LOG.warn("Interrupted during reconnection", interruptedException);
+
+          Thread.currentThread()
+                .interrupt();
+          return;
+        }
+
+        errorCount++;
+      } catch (Throwable e) {
+        try {
+          jsonInput.close();
+        } catch (Throwable suppressed) {
+          e.addSuppressed(suppressed);
+        }
+        throw e;
+      }
+    }
+    jsonInput.close();
+  }
+
+    private void stopReadingAndSleep(JsonInput jsonInput) {
+        jsonInput.close();
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          LOG.debug("Sleeping during discontinued reading interrupted", e);
+        }
     }
 
-    private void verifyReadingCanContinue() throws InterruptedIOException {
-        if (!readerManager.continueReading(eventNames, subscription)) {
-           throw new ReadingDiscontinuedException();
+    private void verifyTerminationIsNotRequested() throws InterruptedIOException {
+        if (readerManager.terminateReader(eventNames, subscription)) {
+            throw new ReadingTerminatedException();
         }
 
-        if (Thread.currentThread().isInterrupted()) {
+        if (Thread.currentThread()
+                  .isInterrupted()) {
             throw new InterruptedIOException("Interrupted");
         }
     }
@@ -423,12 +438,9 @@ class NakadiReader<T> implements IORunnable {
 
     private void expectToken(JsonParser jsonParser, JsonToken expectedToken) throws IOException {
         final JsonToken token = jsonParser.nextToken();
+        verifyTerminationIsNotRequested();
         if (token == null) {
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedIOException("Thread was interrupted");
-            } else {
-                throw new EOFException("Stream was closed");
-            }
+            throw new EOFException("Stream was closed");
         }
         if (token != expectedToken) {
             throw new IOException(String.format("Expected [%s] but got [%s]", expectedToken, token));

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
@@ -1,6 +1,10 @@
 package org.zalando.fahrschein;
 
+import org.zalando.fahrschein.domain.Subscription;
+
+import java.util.Optional;
+
 @FunctionalInterface
 public interface ReaderManager {
-  boolean continueReading();
+  boolean continueReading(Optional<Subscription> subscription);
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
@@ -5,7 +5,8 @@ import org.zalando.fahrschein.domain.Subscription;
 import java.util.Optional;
 import java.util.Set;
 
-@FunctionalInterface
 public interface ReaderManager {
-  boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription);
+  boolean discontinueReading(Set<String> eventNames, Optional<Subscription> subscription);
+
+  boolean terminateReader(Set<String> eventNames, Optional<Subscription> subscription);
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
@@ -3,8 +3,9 @@ package org.zalando.fahrschein;
 import org.zalando.fahrschein.domain.Subscription;
 
 import java.util.Optional;
+import java.util.Set;
 
 @FunctionalInterface
 public interface ReaderManager {
-  boolean continueReading(Optional<Subscription> subscription);
+  boolean continueReading(Set<String> eventNames, Optional<Subscription> subscription);
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReaderManager.java
@@ -1,0 +1,6 @@
+package org.zalando.fahrschein;
+
+@FunctionalInterface
+public interface ReaderManager {
+  boolean continueReading();
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReadingDiscontinuedException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReadingDiscontinuedException.java
@@ -1,0 +1,4 @@
+package org.zalando.fahrschein;
+
+public class ReadingDiscontinuedException extends RuntimeException {
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReadingDiscontinuedException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReadingDiscontinuedException.java
@@ -1,4 +1,0 @@
-package org.zalando.fahrschein;
-
-public class ReadingDiscontinuedException extends RuntimeException {
-}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ReadingTerminatedException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ReadingTerminatedException.java
@@ -1,0 +1,4 @@
+package org.zalando.fahrschein;
+
+public class ReadingTerminatedException extends RuntimeException {
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
@@ -47,7 +47,7 @@ public interface StreamBuilder {
 
     StreamBuilder withBackoffStrategy(BackoffStrategy backoffStrategy);
 
-    StreamBuilder withStopSomething(ReaderManager readerManager);
+    StreamBuilder withReaderManager(ReaderManager readerManager);
 
     <T> void listen(Class<T> eventClass, Listener<T> listener) throws IOException;
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
@@ -47,6 +47,8 @@ public interface StreamBuilder {
 
     StreamBuilder withBackoffStrategy(BackoffStrategy backoffStrategy);
 
+    StreamBuilder withStopSomething(ReaderManager readerManager);
+
     <T> void listen(Class<T> eventClass, Listener<T> listener) throws IOException;
 
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -76,7 +76,7 @@ class StreamBuilders {
         private final Subscription subscription;
 
         SubscriptionStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, Subscription subscription) {
-            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, subscription, subscription1 -> true);
+            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, subscription, new DefaultReaderManager());
         }
 
         private SubscriptionStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, @Nullable BackoffStrategy backoffStrategy, @Nullable StreamParameters streamParameters, @Nullable ErrorHandler errorHandler, @Nullable MetricsCollector metricsCollector, Subscription subscription, ReaderManager readerManager) {
@@ -140,7 +140,7 @@ class StreamBuilders {
         private final Lock lock;
 
         LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, String eventName) {
-            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, (Optional<Subscription> subscription) -> true);
+            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, (Set<String> eventNames, Optional<Subscription> subscription) -> true);
         }
 
         private LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, @Nullable BackoffStrategy backoffStrategy, @Nullable StreamParameters streamParameters, @Nullable ErrorHandler errorHandler, @Nullable MetricsCollector metricsCollector, String eventName, @Nullable Lock lock, @Nullable ReaderManager readerManager) {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -110,7 +110,7 @@ class StreamBuilders {
         }
 
         @Override
-        public SubscriptionStreamBuilder withStopSomething(ReaderManager readerManager) {
+        public SubscriptionStreamBuilder withReaderManager(ReaderManager readerManager) {
             return new SubscriptionStreamBuilderImpl(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, backoffStrategy, streamParameters, errorHandler, metricsCollector, subscription, readerManager);
         }
 
@@ -200,7 +200,7 @@ class StreamBuilders {
         }
 
         @Override
-        public LowLevelStreamBuilder withStopSomething(ReaderManager readerManager) {
+        public LowLevelStreamBuilder withReaderManager(ReaderManager readerManager) {
             return new LowLevelStreamBuilderImpl(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, backoffStrategy, streamParameters, errorHandler, metricsCollector, eventName, lock, readerManager);
         }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -140,7 +140,7 @@ class StreamBuilders {
         private final Lock lock;
 
         LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, String eventName) {
-            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, (Set<String> eventNames, Optional<Subscription> subscription) -> true);
+            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, new DefaultReaderManager());
         }
 
         private LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, @Nullable BackoffStrategy backoffStrategy, @Nullable StreamParameters streamParameters, @Nullable ErrorHandler errorHandler, @Nullable MetricsCollector metricsCollector, String eventName, @Nullable Lock lock, @Nullable ReaderManager readerManager) {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -76,7 +76,7 @@ class StreamBuilders {
         private final Subscription subscription;
 
         SubscriptionStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, Subscription subscription) {
-            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, subscription, () -> true);
+            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, subscription, subscription1 -> true);
         }
 
         private SubscriptionStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, @Nullable BackoffStrategy backoffStrategy, @Nullable StreamParameters streamParameters, @Nullable ErrorHandler errorHandler, @Nullable MetricsCollector metricsCollector, Subscription subscription, ReaderManager readerManager) {
@@ -140,7 +140,7 @@ class StreamBuilders {
         private final Lock lock;
 
         LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, String eventName) {
-            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, () -> true);
+            this(baseUri, clientHttpRequestFactory, cursorManager, objectMapper, null, null, null, null, eventName, null, (Optional<Subscription> subscription) -> true);
         }
 
         private LowLevelStreamBuilderImpl(URI baseUri, ClientHttpRequestFactory clientHttpRequestFactory, CursorManager cursorManager, ObjectMapper objectMapper, @Nullable BackoffStrategy backoffStrategy, @Nullable StreamParameters streamParameters, @Nullable ErrorHandler errorHandler, @Nullable MetricsCollector metricsCollector, String eventName, @Nullable Lock lock, @Nullable ReaderManager readerManager) {

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -143,7 +143,7 @@ public class NakadiReaderDeserializationTest {
     private <T> List<T> readSingleBatch(String eventName, Class<T> eventClass) throws IOException {
         final List<T> result = new ArrayList<>();
         final NakadiReader<T> nakadiReader = new NakadiReader<T>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
-                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, (Set<String> eventNames, Optional<Subscription> subscription) -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
+                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, new DefaultReaderManager(), NoMetricsCollector.NO_METRICS_COLLECTOR);
         nakadiReader.readSingleBatch();
 
         return result;

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -20,10 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
@@ -146,7 +143,7 @@ public class NakadiReaderDeserializationTest {
     private <T> List<T> readSingleBatch(String eventName, Class<T> eventClass) throws IOException {
         final List<T> result = new ArrayList<>();
         final NakadiReader<T> nakadiReader = new NakadiReader<T>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
-                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, (Optional<Subscription> subscription) -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
+                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, (Set<String> eventNames, Optional<Subscription> subscription) -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
         nakadiReader.readSingleBatch();
 
         return result;

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -150,7 +150,7 @@ public class NakadiReaderDeserializationTest {
     private <T> List<T> readSingleBatch(String eventName, Class<T> eventClass) throws IOException {
         final List<T> result = new ArrayList<>();
         final NakadiReader<T> nakadiReader = new NakadiReader<T>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
-                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR);
+                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, () -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
         nakadiReader.readSingleBatch();
 
         return result;

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -13,11 +13,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
-import org.zalando.fahrschein.domain.AbstractDataChangeEvent;
-import org.zalando.fahrschein.domain.DataChangeEvent;
-import org.zalando.fahrschein.domain.DataOperation;
-import org.zalando.fahrschein.domain.Event;
-import org.zalando.fahrschein.domain.Metadata;
+import org.zalando.fahrschein.domain.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -150,7 +146,7 @@ public class NakadiReaderDeserializationTest {
     private <T> List<T> readSingleBatch(String eventName, Class<T> eventClass) throws IOException {
         final List<T> result = new ArrayList<>();
         final NakadiReader<T> nakadiReader = new NakadiReader<T>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
-                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, () -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
+                Collections.singleton(eventName), Optional.empty(), Optional.empty(), eventClass, result::addAll, DefaultErrorHandler.INSTANCE, (Optional<Subscription> subscription) -> true, NoMetricsCollector.NO_METRICS_COLLECTOR);
         nakadiReader.readSingleBatch();
 
         return result;

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.hobsoft.hamcrest.compose.ComposeMatchers;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,6 +70,11 @@ public class NakadiReaderTest {
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        when(listener.isActive()).thenReturn(true);
+    }
 
     public static class SomeEvent {
         private String id;

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.hobsoft.hamcrest.compose.ComposeMatchers;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,6 +18,7 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.zalando.fahrschein.domain.Cursor;
 import org.zalando.fahrschein.domain.Lock;
 import org.zalando.fahrschein.domain.Partition;
+import org.zalando.fahrschein.domain.Subscription;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -63,7 +63,7 @@ public class NakadiReaderTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CursorManager cursorManager = mock(CursorManager.class);
     private final ErrorHandler errorHandler = DefaultErrorHandler.INSTANCE;
-    private final ReaderManager readerManager = () -> true;
+    private final ReaderManager readerManager = (Optional<Subscription> subscription) -> true;
     private final ClientHttpRequestFactory clientHttpRequestFactory = mock(ClientHttpRequestFactory.class);
 
     @SuppressWarnings("unchecked")
@@ -623,7 +623,7 @@ public class NakadiReaderTest {
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
 
-        ReaderManager readerManager = () -> false;
+        ReaderManager readerManager = (Optional<Subscription> subscription) -> false;
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -32,10 +32,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -63,7 +60,7 @@ public class NakadiReaderTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CursorManager cursorManager = mock(CursorManager.class);
     private final ErrorHandler errorHandler = DefaultErrorHandler.INSTANCE;
-    private final ReaderManager readerManager = (Optional<Subscription> subscription) -> true;
+    private final ReaderManager readerManager = new DefaultReaderManager();
     private final ClientHttpRequestFactory clientHttpRequestFactory = mock(ClientHttpRequestFactory.class);
 
     @SuppressWarnings("unchecked")
@@ -623,7 +620,7 @@ public class NakadiReaderTest {
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
 
-        ReaderManager readerManager = (Optional<Subscription> subscription) -> false;
+        ReaderManager readerManager = (Set<String> eventNames, Optional<Subscription> subscription) -> false;
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -625,6 +625,8 @@ public class NakadiReaderTest {
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
+        expectedException.expect(ReadingDiscontinuedException.class);
+
         nakadiReader.run();
 
         verify(listener).accept(any(List.class));
@@ -653,6 +655,8 @@ public class NakadiReaderTest {
         when(readerManager.continueReading(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false);
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
+
+        expectedException.expect(ReadingDiscontinuedException.class);
 
         nakadiReader.run();
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -604,7 +604,7 @@ public class NakadiReaderTest {
     }
 
     @Test
-    public void shouldCloseAfterReaderManagerDecidesToNotContinueReading() throws Exception {
+    public void shouldCloseAfterReaderManagerDecidesToTerminateReading() throws Exception {
         final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"foo\":\"bar\",\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(inputStream);
@@ -621,11 +621,11 @@ public class NakadiReaderTest {
         ReaderManager readerManager = mock(ReaderManager.class);
         Optional<Subscription> subscription = Optional.empty();
 
-        when(readerManager.continueReading(Collections.singleton(EVENT_NAME), subscription)).thenReturn(true).thenReturn(false);
+        when(readerManager.terminateReader(Collections.singleton(EVENT_NAME), subscription)).thenReturn(true).thenReturn(false);
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
-        expectedException.expect(ReadingDiscontinuedException.class);
+        expectedException.expect(ReadingTerminatedException.class);
 
         nakadiReader.run();
 
@@ -635,7 +635,7 @@ public class NakadiReaderTest {
     }
 
     @Test
-    public void shouldNotStartReadingWhenReaderManagerDisablesReadingDirectly() throws Exception {
+    public void shouldNotStartReadingWhenReaderManagerTerminatesReadingDirectly() throws Exception {
         final ClientHttpResponse response = mock(ClientHttpResponse.class);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"foo\":\"bar\",\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
         when(response.getBody()).thenReturn(inputStream);
@@ -652,15 +652,79 @@ public class NakadiReaderTest {
         ReaderManager readerManager = mock(ReaderManager.class);
         Optional<Subscription> subscription = Optional.empty();
 
-        when(readerManager.continueReading(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false);
+        when(readerManager.terminateReader(Collections.singleton(EVENT_NAME), subscription)).thenReturn(true);
 
         final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
-        expectedException.expect(ReadingDiscontinuedException.class);
+        expectedException.expect(ReadingTerminatedException.class);
 
         nakadiReader.run();
 
         verifyZeroInteractions(listener);
+        verify(request).execute();
+        verify(response).close();
+    }
+
+    @Test
+    public void shouldCloseAfterReaderManagerDecidesToDiscontinueReading() throws Exception {
+        final ClientHttpResponse response = mock(ClientHttpResponse.class);
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"foo\":\"bar\",\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
+        when(response.getBody()).thenReturn(inputStream);
+
+        final ClientHttpRequest request = mock(ClientHttpRequest.class);
+        when(request.execute()).thenReturn(response);
+        final HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+
+        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        ReaderManager readerManager = mock(ReaderManager.class);
+        Optional<Subscription> subscription = Optional.empty();
+
+        when(readerManager.discontinueReading(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false).thenReturn(true);
+        when(readerManager.terminateReader(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false).thenReturn(false).thenReturn(true);
+
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
+
+        expectedException.expect(ReadingTerminatedException.class);
+
+        nakadiReader.run();
+
+        verify(listener).accept(any(List.class));
+        verify(request).execute();
+        verify(response).close();
+    }
+
+    @Test
+    public void shouldReadAgainReaderManagerDecidesToContinueReading() throws Exception {
+        final ClientHttpResponse response = mock(ClientHttpResponse.class);
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"123\",\"offset\":\"456\"},\"foo\":\"bar\",\"events\":[{\"id\":\"789\"}],\"metadata\":{\"foo\":\"bar\"}}".getBytes("utf-8"));
+        when(response.getBody()).thenReturn(inputStream, inputStream, inputStream, inputStream);
+
+        final ClientHttpRequest request = mock(ClientHttpRequest.class);
+        when(request.execute()).thenReturn(response);
+        final HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+
+        when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        ReaderManager readerManager = mock(ReaderManager.class);
+        Optional<Subscription> subscription = Optional.empty();
+
+        when(readerManager.discontinueReading(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false, true);
+        when(readerManager.terminateReader(Collections.singleton(EVENT_NAME), subscription)).thenReturn(false, false, false, true);
+
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), subscription, Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
+
+        expectedException.expect(ReadingTerminatedException.class);
+
+        nakadiReader.run();
+
+        verify(listener, times(2)).accept(any(List.class));
         verify(request).execute();
         verify(response).close();
     }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -63,6 +63,7 @@ public class NakadiReaderTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CursorManager cursorManager = mock(CursorManager.class);
     private final ErrorHandler errorHandler = DefaultErrorHandler.INSTANCE;
+    private final ReaderManager readerManager = () -> true;
     private final ClientHttpRequestFactory clientHttpRequestFactory = mock(ClientHttpRequestFactory.class);
 
     @SuppressWarnings("unchecked")
@@ -70,11 +71,6 @@ public class NakadiReaderTest {
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void setup() {
-        when(listener.isActive()).thenReturn(true);
-    }
 
     public static class SomeEvent {
         private String id;
@@ -97,7 +93,7 @@ public class NakadiReaderTest {
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
 
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(IOException.class);
         expectedException.expectMessage(equalTo("Initial connection failed"));
@@ -117,7 +113,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature("retries", BackoffException::getRetries, equalTo(0)));
@@ -138,7 +134,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -160,7 +156,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -182,7 +178,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 1);
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(1)));
@@ -204,7 +200,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(4)));
@@ -226,7 +222,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(4)));
@@ -279,7 +275,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         //expectedException.expect(InterruptedException.class);
 
@@ -330,7 +326,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final BackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(2);
         final Future<?> future = scheduledExecutorService.submit(() -> {
@@ -357,7 +353,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         final Future<?> future = Executors.newCachedThreadPool().submit(nakadiReader.unchecked());
         Assert.assertNull("Thread should have completed normally", future.get());
@@ -382,7 +378,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final ExponentialBackoffStrategy backoffStrategy = new ExponentialBackoffStrategy(1, 1, 2, 4);
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         final Future<?> future = Executors.newCachedThreadPool().submit(nakadiReader.unchecked());
         Assert.assertNull("Thread should have completed normally", future.get());
@@ -402,7 +398,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         // cannot use expectedException since there should be assertions afterwards
         try {
@@ -447,7 +443,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -470,7 +466,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -493,7 +489,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -516,7 +512,7 @@ public class NakadiReaderTest {
         when(clientHttpRequestFactory.createRequest(uri, HttpMethod.GET)).thenReturn(request);
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(BackoffException.class);
         expectedException.expect(ComposeMatchers.hasFeature(BackoffException::getRetries, equalTo(0)));
@@ -540,7 +536,7 @@ public class NakadiReaderTest {
         when(cursorManager.getCursors(EVENT_NAME)).thenReturn(asList(new Cursor("0", "0"), new Cursor("1", "10"), new Cursor("2", "20"), new Cursor("3", "30")));
 
         final Lock lock = new Lock(EVENT_NAME, "test", asList(new Partition("0", "0", "100"), new Partition("1", "0", "100")));
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.of(lock), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.of(lock), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         expectedException.expect(IOException.class);
         expectedException.expectMessage(equalTo("Initial connection failed"));
@@ -569,7 +565,7 @@ public class NakadiReaderTest {
             throw new FileNotFoundException("from listener");
         };
 
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         try {
             nakadiReader.run();
@@ -600,7 +596,7 @@ public class NakadiReaderTest {
             throw new RuntimeException("from listener");
         };
 
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         try {
             nakadiReader.run();
@@ -627,19 +623,9 @@ public class NakadiReaderTest {
 
         final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
 
-        final Listener<SomeEvent> listener = new Listener<SomeEvent>() {
-            @Override
-            public void accept(List<SomeEvent> events) throws IOException, EventAlreadyProcessedException {
+        ReaderManager readerManager = () -> false;
 
-            }
-
-            @Override
-            public boolean isActive() {
-                return false;
-            }
-        };
-
-        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, NO_METRICS_COLLECTOR);
+        final NakadiReader<SomeEvent> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), SomeEvent.class, listener, errorHandler, readerManager, NO_METRICS_COLLECTOR);
 
         nakadiReader.run();
 


### PR DESCRIPTION
This change introduces a reader manager that allows the client to stop the nakadireader without exposing it to the client

This change will remove the problem that a user has either to call Thread.currentThread.interrupt() or throw an RuntimeException from the listener implementation.