### PR TITLE
Stopping and resuming reader with executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,27 @@ Exception handling while streaming events follows some simple rules
  - If an `IOException` happens when opening the initial connection, this is not retried as it probably indicates a configuration problem (wrong host name or missing scopes)
  - Exceptions in other client methods are not automatically retried
 
+## Stopping and resuming streams
+
+The stream implementation gracefully handles thread interruption, so it is possible to stop a running thread and resume consuming events by re-submitting the `Runnable`:
+
+```java
+final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+final Runnable runnable = nakadiClient.stream(SALES_ORDER_SERVICE_ORDER_PLACED)
+        .runnable(SalesOrderPlaced.class, listener)
+        .unchecked();
+
+// start consuming events
+final Future<?> future = executorService.submit(runnable);
+
+// stop consuming events
+future.cancel(true);
+
+// resume consuming events
+final Future<?> future2 = executorService.submit(runnable);
+```
+
 ### Handling data binding problems
 
 You might want to ignore events that could not be mapped to your domain objects by Jackson, instead of having these events block all further processing.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,15 @@ Exception handling while streaming events follows some simple rules
 
 ### Handling data binding problems
 
-You might want to ignore events that could not be mapped to your domain objects by Jackson, instead of having these events block all further processing. To achieve this you can override the `onMappingException` method of `Listener` and handle the `JsonMappingException` yourself.
+You might want to ignore events that could not be mapped to your domain objects by Jackson, instead of having these events block all further processing.
+To achieve this you can implement the `onMappingException` method of the `ErrorHandler` interface handle the `JsonMappingException` yourself.
+
+```java
+nakadiClient.stream(eventName)
+        .withErrorHandler(e -> {...})
+        .listen(SalesOrderPlaced.class, listener);
+
+```
 
 ## Using another ClientHttpRequestFactory
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,6 @@ nakadiClient.stream(subscription)
 
 See [`Main.java`](src/test/java/org/zalando/fahrschein/salesorder/Main.java) for an executable version of the above code.
 
-## Fahrschein compared to other nakadi client libraries
-
-|                      | Fahrschein                                                        | Nakadi-Klients        | Reactive-Nakadi         | Straw               |
-| -------------------- | ----------------------------------------------------------------- | --------------------- | ----------------------- | ------------------- |
-| Dependencies         | Spring (http client and jdbc), Jackson                            | Scala, Akka, Jackson  | Scala, Akka             | None                |
-| Cursor Management    | In-Memory / Persistent (Postgres or Redis)                        | In-Memory             | Persistent (Dynamo)     |                     |
-| Partition Management | In-Memory / Persistent (Postgres)                                 |                       | Persistent (Dynamo) (?) |                     |
-| Error Handling       | Automatic reconnect with exponential backoff                      | Automatic reconnect   | (?)                     | No error handling   |
-
 ## Initializing partition offsets
 
 By default nakadi will start streaming from the most recent offset. The initial offsets can be changed by requesting data about partitions from Nakadi and using this data to configure `CursorManager`.
@@ -164,6 +155,15 @@ nakadiClient.stream(eventName)
 This library is currently tested and used in production with `SimpleClientHttpRequestFactory` and `HttpComponentsClientHttpRequestFactory`.
 
 Please note that `HttpComponentsClientHttpRequestFactory` and also `SimpleClientHttpRequestFactory` since spring 4.3.x try to consume the remaining stream on closing and so might block during reconnection.
+
+## Fahrschein compared to other nakadi client libraries
+
+|                      | Fahrschein                                                        | Nakadi-Klients        | Reactive-Nakadi         | Straw               |
+| -------------------- | ----------------------------------------------------------------- | --------------------- | ----------------------- | ------------------- |
+| Dependencies         | Spring (http client and jdbc), Jackson                            | Scala, Akka, Jackson  | Scala, Akka             | None                |
+| Cursor Management    | In-Memory / Persistent (Postgres or Redis)                        | In-Memory             | Persistent (Dynamo)     |                     |
+| Partition Management | In-Memory / Persistent (Postgres)                                 |                       | Persistent (Dynamo) (?) |                     |
+| Error Handling       | Automatic reconnect with exponential backoff                      | Automatic reconnect   | (?)                     | No error handling   |
 
 ## Getting help
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilder.java
@@ -47,6 +47,7 @@ public interface StreamBuilder {
 
     StreamBuilder withBackoffStrategy(BackoffStrategy backoffStrategy);
 
+    <T> IORunnable runnable(Class<T> eventClass, Listener<T> listener);
     <T> void listen(Class<T> eventClass, Listener<T> listener) throws IOException;
 
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -10,9 +10,11 @@ import org.zalando.fahrschein.domain.Subscription;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Optional.ofNullable;
 import static java.util.function.Function.identity;
@@ -52,6 +54,11 @@ class StreamBuilders {
 
         @Override
         public final <T> void listen(Class<T> eventClass, Listener<T> listener) throws IOException {
+            runnable(eventClass, listener).run();
+        }
+
+        @Override
+        public final <T> IORunnable runnable(Class<T> eventClass, Listener<T> listener) {
             final StreamParameters streamParameters = this.streamParameters != null ? this.streamParameters : new StreamParameters();
             final String queryString = streamParameters.toQueryString();
 
@@ -64,9 +71,8 @@ class StreamBuilders {
             final MetricsCollector metricsCollector = this.metricsCollector != null ? this.metricsCollector : NoMetricsCollector.NO_METRICS_COLLECTOR;
             final ErrorHandler errorHandler = this.errorHandler != null ? this.errorHandler : DefaultErrorHandler.INSTANCE;
 
-            final NakadiReader<T> nakadiReader = new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper, eventNames, subscription, lock, eventClass, listener, errorHandler, metricsCollector);
-
-            nakadiReader.run();
+            return new NakadiReader<>(uri, clientHttpRequestFactory, backoffStrategy, cursorManager, objectMapper,
+                    eventNames, subscription, lock, eventClass, listener, errorHandler, metricsCollector);
         }
 
     }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -610,7 +610,7 @@ public class NakadiReaderTest {
         }
     }
 
-    @Test()
+    @Test(timeout = 2000)
     public void shouldStopAndResumeReading() throws IOException, InterruptedException, BackoffException, ExecutionException, TimeoutException, EventAlreadyProcessedException {
         final InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
         final ServerSocket serverSocket = new ServerSocket(0, 0, loopbackAddress);
@@ -627,7 +627,7 @@ public class NakadiReaderTest {
                             out.flush();
                             while (true) {
                                 try {
-                                    Thread.sleep(20);
+                                    Thread.sleep(10);
                                 } catch (InterruptedException e) {
                                     break;
                                 }


### PR DESCRIPTION
Example how #161 can already be achieved with the current code. Introduces new `runnable` method on `StreamBuilder` to simplify using it in a thread pool.