### PR TITLE
Make ProblemHandlingClientHttpRequestFactory and AuthorizedClientHttpRequestFactory public

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizedClientHttpRequestFactory.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizedClientHttpRequestFactory.java
@@ -9,7 +9,7 @@ import java.net.URI;
 
 import static java.util.Collections.singletonList;
 
-class AuthorizedClientHttpRequestFactory implements ClientHttpRequestFactory {
+public class AuthorizedClientHttpRequestFactory implements ClientHttpRequestFactory {
     private final ClientHttpRequestFactory delegate;
     private final AccessTokenProvider accessTokenProvider;
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingClientHttpRequestFactory.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingClientHttpRequestFactory.java
@@ -7,7 +7,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import java.io.IOException;
 import java.net.URI;
 
-class ProblemHandlingClientHttpRequestFactory implements ClientHttpRequestFactory {
+public class ProblemHandlingClientHttpRequestFactory implements ClientHttpRequestFactory {
     private final ClientHttpRequestFactory delegate;
 
     public ProblemHandlingClientHttpRequestFactory(ClientHttpRequestFactory delegate) {


### PR DESCRIPTION
`ProblemHandlingClientHttpRequestFactory` and `AuthorizedClientHttpRequestFactory` were made public to allow their usage outside the library. For example, this might be necessary for implementing a custom `CursorManager`, derived from `ManagedCursorManager` (to pass to the constructor).